### PR TITLE
Set defaults for endpoint URLs

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -85,8 +85,8 @@ function getKubeconfig() {
         let servicePrincipalId = credsObject["clientId"];
         let servicePrincipalKey = credsObject["clientSecret"];
         let tenantId = credsObject["tenantId"];
-        let authorityUrl = credsObject["activeDirectoryEndpointUrl"];
-        let managementEndpointUrl = credsObject["resourceManagerEndpointUrl"];
+        let authorityUrl = credsObject["activeDirectoryEndpointUrl"] || "https://login.microsoftonline.com";
+        let managementEndpointUrl = credsObject["resourceManagerEndpointUrl"] || "https://management.azure.com/";
         let subscriptionId = credsObject["subscriptionId"];
         let azureSessionToken = yield getAzureAccessToken(servicePrincipalId, servicePrincipalKey, tenantId, authorityUrl);
         let kubeconfig = yield getAKSKubeconfig(azureSessionToken, subscriptionId, managementEndpointUrl);

--- a/src/login.ts
+++ b/src/login.ts
@@ -82,8 +82,8 @@ async function getKubeconfig(): Promise<string> {
     let servicePrincipalId = credsObject["clientId"];
     let servicePrincipalKey = credsObject["clientSecret"];
     let tenantId = credsObject["tenantId"];
-    let authorityUrl = credsObject["activeDirectoryEndpointUrl"];
-    let managementEndpointUrl = credsObject["resourceManagerEndpointUrl"];
+    let authorityUrl = credsObject["activeDirectoryEndpointUrl"] || "https://login.microsoftonline.com";
+    let managementEndpointUrl = credsObject["resourceManagerEndpointUrl"] || "https://management.azure.com/";
     let subscriptionId = credsObject["subscriptionId"];
     let azureSessionToken = await getAzureAccessToken(servicePrincipalId, servicePrincipalKey, tenantId, authorityUrl);
     let kubeconfig = await getAKSKubeconfig(azureSessionToken, subscriptionId, managementEndpointUrl);


### PR DESCRIPTION
@ds-ms This fixes the issue mentioned in https://github.com/Azure/k8s-actions/issues/33 where it's not clear that values for `activeDirectoryEndpointUrl` and `resourceManagerEndpointUrl` are required.

Since it looks like both of those values are generally static, this PR sets defaults to prevent unclear errors. I could also update the error message instead, but this seemed like a more straightforward approach