### PR TITLE
handles clusterUser access profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Refer to [starter templates](https://github.com/Azure/actions-workflow-samples/t
     <td><code>cluster-name</code><br/>Cluster name</td>
     <td>(Required) Name of the AKS cluster</td>
   </tr>
+  <tr>
+    <td><code>admin</code><br/>admin</td>
+    <td>(Optional) default <code>true</code> for admin credentials, <code>false</code> gets the clusterUser credentials instead.</td>
+  </tr>
 </table>
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,24 @@
-name: "Azure Kubernetes set context"
-description: "Sets the kubeconfig on the machine to communicate with the Azure Kubernetes cluster. Github.com/Azure/Actions"
+name: 'Azure Kubernetes set context'
+description: 'Sets the kubeconfig on the machine to communicate with the Azure Kubernetes cluster. Github.com/Azure/Actions'
 inputs:
   creds:
-    description: "Azure credentials i.e. output of `az ad sp create-for-rbac --sdk-auth`"
+    description: 'Azure credentials i.e. output of `az ad sp create-for-rbac --sdk-auth`'
     required: true
-    default: ""
+    default: ''
   resource-group:
-    description: "Resource Group Name"
+    description: 'Resource Group Name'
     required: false
-    default: ""
+    default: ''
   cluster-name:
-    description: "AKS Cluster Name"
+    description: 'AKS Cluster Name'
     required: false
-    default: ""
+    default: ''
   admin:
-    description: "Is context user admin, set to `'false'` to use clusterUser creds instead."
+    description: 'Is context user admin, set to `'false'` to use clusterUser creds instead.'
     required: false
-    default: "true"
+    default: 'true'
 branding:
-  color: "green" # optional, decorates the entry in the GitHub Marketplace
+  color: 'green' # optional, decorates the entry in the GitHub Marketplace
 runs:
-  using: "node12"
-  main: "lib/login.js"
+  using: 'node12'
+  main: 'lib/login.js'

--- a/action.yml
+++ b/action.yml
@@ -1,20 +1,24 @@
-name: 'Azure Kubernetes set context'
-description: 'Sets the kubeconfig on the machine to communicate with the Azure Kubernetes cluster. Github.com/Azure/Actions'
-inputs: 
+name: "Azure Kubernetes set context"
+description: "Sets the kubeconfig on the machine to communicate with the Azure Kubernetes cluster. Github.com/Azure/Actions"
+inputs:
   creds:
-    description: 'Azure credentials i.e. output of `az ad sp create-for-rbac --sdk-auth`'
+    description: "Azure credentials i.e. output of `az ad sp create-for-rbac --sdk-auth`"
     required: true
-    default: ''
+    default: ""
   resource-group:
-    description: 'Resource Group Name'
+    description: "Resource Group Name"
     required: false
-    default: ''
+    default: ""
   cluster-name:
-    description: 'AKS Cluster Name'
+    description: "AKS Cluster Name"
     required: false
-    default: ''
+    default: ""
+  admin:
+    description: "Is context user admin, set to `'false'` to use clusterUser creds instead."
+    required: false
+    default: "true"
 branding:
-  color: 'green' # optional, decorates the entry in the GitHub Marketplace
+  color: "green" # optional, decorates the entry in the GitHub Marketplace
 runs:
-  using: 'node12'
-  main: 'lib/login.js'
+  using: "node12"
+  main: "lib/login.js"

--- a/src/login.ts
+++ b/src/login.ts
@@ -7,10 +7,12 @@ import { getAzureAccessToken } from '@azure-actions/auth';
 export function getAKSKubeconfig(azureSessionToken: string, subscriptionId: string, managementEndpointUrl: string): Promise<string> {
     let resourceGroupName = core.getInput('resource-group', { required: true });
     let clusterName = core.getInput('cluster-name', { required: true });
+    let admin = (core.getInput('admin').toUpperCase() === 'TRUE')
     return new Promise<string>((resolve, reject) => {
         var webRequest = new WebRequest();
         webRequest.method = 'GET';
-        webRequest.uri = `${managementEndpointUrl}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/${clusterName}/accessProfiles/clusterAdmin?api-version=2017-08-31`;
+        var accessProfile = admin ? 'clusterAdmin' : 'clusterUser';
+        webRequest.uri = `${managementEndpointUrl}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/${clusterName}/accessProfiles/${accessProfile}?api-version=2017-08-31`;
         webRequest.headers = {
             'Authorization': 'Bearer ' + azureSessionToken,
             'Content-Type': 'application/json; charset=utf-8'


### PR DESCRIPTION
fixes #25 

opening draft PR for feedback as per https://github.com/Azure/aks-set-context/issues/25#issuecomment-795718226

- updates readme
- `core.getInput()` only supports strings, I think might be better to update `@actions/core` as I think there is a new [`getBooleanInput `](https://github.com/actions/toolkit/pull/725) function that can be leveraged.
- [`Microsoft.ContainerService/managedClusters`](https://docs.microsoft.com/en-us/rest/api/aks/managedclusters/getaccessprofile?source=docs) has a new [`listClusterUserCredential`](https://docs.microsoft.com/en-us/rest/api/aks/managedclusters/listclusterusercredentials) and [`listClusterAdminCredential`](https://docs.microsoft.com/en-us/rest/api/aks/managedclusters/listclusteradmincredentials) `2021-03-01` api version we should probably use instead.

Also looking for a way to test the action locally, anyone know ?