### PR TITLE
Allow selection of subscription-id

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
   cluster-name:
     description: 'AKS Cluster Name'
     required: false
+    default: ''  
+  subscription-id:
+    description: 'Subscription ID'
+    required: false
     default: ''
 branding:
   color: 'green' # optional, decorates the entry in the GitHub Marketplace

--- a/lib/login.js
+++ b/lib/login.js
@@ -50,7 +50,7 @@ function getKubeconfig() {
             throw new Error('Credentials object is not a valid JSON');
         }
         const managementEndpointUrl = credsObject["resourceManagerEndpointUrl"] || "https://management.azure.com/";
-        const subscriptionId = credsObject["subscriptionId"];
+        const subscriptionId = core.getInput('subscription-id') || credsObject["subscriptionId"];
         const azureSessionToken = yield auth_1.getAzureAccessToken(creds);
         const kubeconfig = yield getAKSKubeconfig(azureSessionToken, subscriptionId, managementEndpointUrl);
         return kubeconfig;

--- a/src/login.ts
+++ b/src/login.ts
@@ -37,7 +37,7 @@ export async function getKubeconfig(): Promise<string> {
     }
 
     const managementEndpointUrl = credsObject["resourceManagerEndpointUrl"] || "https://management.azure.com/";
-    const subscriptionId = credsObject["subscriptionId"];
+    const subscriptionId = core.getInput('subscription-id') || credsObject["subscriptionId"];
     const azureSessionToken = await getAzureAccessToken(creds);
     const kubeconfig = await getAKSKubeconfig(azureSessionToken, subscriptionId, managementEndpointUrl);
     return kubeconfig;


### PR DESCRIPTION
This should fix #41.

We need it because we have creds for multiple subscriptions in a single secret which we need to release to multiple environments.
