### PR TITLE
separate execution and run function, bump release workflow hash

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
    release:
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@81e6a8ed41ced9d131dea884ecae7b8c6dc4f799
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@a705b2ab6a3ee889f2b0d925ad0bd2f9eb733ce6
       with:
          changelogPath: ./CHANGELOG.md

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
 branding:
    color: 'green'
 runs:
-   using: 'node16'
+   using: 'node20'
    main: 'lib/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "aks-set-context-action",
-   "version": "0.0.1",
+   "version": "3.3.0",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
          "name": "aks-set-context-action",
-         "version": "0.0.1",
+         "version": "3.3.0",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^1.10.0",
@@ -4904,9 +4904,9 @@
          "dev": true
       },
       "node_modules/jest-snapshot/node_modules/semver": {
-         "version": "7.3.7",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-         "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+         "version": "7.6.0",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+         "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
          "dev": true,
          "dependencies": {
             "lru-cache": "^6.0.0"
@@ -5525,9 +5525,9 @@
          }
       },
       "node_modules/node-notifier/node_modules/semver": {
-         "version": "7.3.7",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-         "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+         "version": "7.6.0",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+         "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
          "dev": true,
          "optional": true,
          "dependencies": {
@@ -5559,9 +5559,9 @@
          }
       },
       "node_modules/normalize-package-data/node_modules/semver": {
-         "version": "5.7.1",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-         "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+         "version": "5.7.2",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+         "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
          "dev": true,
          "bin": {
             "semver": "bin/semver"
@@ -6451,9 +6451,9 @@
          }
       },
       "node_modules/sane/node_modules/semver": {
-         "version": "5.7.1",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-         "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+         "version": "5.7.2",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+         "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
          "dev": true,
          "bin": {
             "semver": "bin/semver"
@@ -6518,9 +6518,9 @@
          }
       },
       "node_modules/semver": {
-         "version": "6.3.0",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-         "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+         "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
          "dev": true,
          "bin": {
             "semver": "bin/semver.js"
@@ -7279,9 +7279,9 @@
          }
       },
       "node_modules/ts-jest/node_modules/semver": {
-         "version": "7.3.7",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-         "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+         "version": "7.6.0",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+         "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
          "dev": true,
          "dependencies": {
             "lru-cache": "^6.0.0"
@@ -11633,9 +11633,9 @@
                "dev": true
             },
             "semver": {
-               "version": "7.3.7",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-               "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+               "version": "7.6.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+               "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
                "dev": true,
                "requires": {
                   "lru-cache": "^6.0.0"
@@ -12122,9 +12122,9 @@
          },
          "dependencies": {
             "semver": {
-               "version": "7.3.7",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-               "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+               "version": "7.6.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+               "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
                "dev": true,
                "optional": true,
                "requires": {
@@ -12152,9 +12152,9 @@
          },
          "dependencies": {
             "semver": {
-               "version": "5.7.1",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+               "version": "5.7.2",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+               "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                "dev": true
             }
          }
@@ -12836,9 +12836,9 @@
                "dev": true
             },
             "semver": {
-               "version": "5.7.1",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+               "version": "5.7.2",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+               "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                "dev": true
             },
             "shebang-command": {
@@ -12887,9 +12887,9 @@
          }
       },
       "semver": {
-         "version": "6.3.0",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-         "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+         "version": "6.3.1",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+         "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
          "dev": true
       },
       "set-blocking": {
@@ -13497,9 +13497,9 @@
          },
          "dependencies": {
             "semver": {
-               "version": "7.3.7",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-               "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+               "version": "7.6.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+               "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
                "dev": true,
                "requires": {
                   "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
    "private": true,
    "main": "lib/login.js",
    "scripts": {
-      "build": "ncc build src/run.ts -o lib",
+      "build": "ncc build src/index.ts -o lib",
       "test": "jest",
       "test-coverage": "jest --coverage",
       "format": "prettier --write .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+import {run} from './run'
+import * as core from '@actions/core'
+
+run().catch(core.setFailed)

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -25,6 +25,7 @@ describe('Set context', () => {
             .spyOn(core, 'getInput')
             .mockImplementation((inputName, options) => {
                if (inputName == 'resource-group') return resourceGroup
+               if (inputName == 'cluster-name') return ''
             })
          await expect(run()).rejects.toThrow()
       },

--- a/src/run.ts
+++ b/src/run.ts
@@ -104,5 +104,3 @@ function getUserAgent(prevUserAgent: string): string {
    if (prevUserAgent) return `${prevUserAgent}+${newUserAgent}`
    return newUserAgent
 }
-
-run().catch(core.setFailed)


### PR DESCRIPTION
- the previous implementation executed the run function on import, this change separate the definition of the function from the script `index.ts` that executes it, allowing tests to run without executing an action run on import.

- bump the node version to 20 from 16

- bump release workflow version hash