### PR TITLE
remove deprecated crypto package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
          "dependencies": {
             "@actions/core": "^1.10.0",
             "@actions/exec": "^1.1.0",
-            "@actions/io": "^1.1.1",
-            "crypto": "^1.0.1"
+            "@actions/io": "^1.1.1"
          },
          "devDependencies": {
             "@types/jest": "^25.2.2",
@@ -2241,12 +2240,6 @@
          "engines": {
             "node": ">= 8"
          }
-      },
-      "node_modules/crypto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-         "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-         "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
       },
       "node_modules/cssom": {
          "version": "0.4.4",
@@ -9530,11 +9523,6 @@
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
          }
-      },
-      "crypto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-         "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
       },
       "cssom": {
          "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
    "dependencies": {
       "@actions/core": "^1.10.0",
       "@actions/exec": "^1.1.0",
-      "@actions/io": "^1.1.1",
-      "crypto": "^1.0.1"
+      "@actions/io": "^1.1.1"
    },
    "devDependencies": {
       "@types/jest": "^25.2.2",

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -26,6 +26,7 @@ describe('Set context', () => {
             .mockImplementation((inputName, options) => {
                if (inputName == 'resource-group') return resourceGroup
                if (inputName == 'cluster-name') return ''
+	       return ''
             })
          await expect(run()).rejects.toThrow()
       },

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -26,7 +26,7 @@ describe('Set context', () => {
             .mockImplementation((inputName, options) => {
                if (inputName == 'resource-group') return resourceGroup
                if (inputName == 'cluster-name') return ''
-	       return ''
+               return ''
             })
          await expect(run()).rejects.toThrow()
       },

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,7 +3,7 @@ import * as io from '@actions/io'
 import * as exec from '@actions/exec'
 import * as path from 'path'
 import * as fs from 'fs'
-import * as crypto from 'crypto'
+import {createHash} from 'crypto'
 
 const AZ_TOOL_NAME = 'az'
 const KUBELOGIN_TOOL_NAME = 'kubelogin'
@@ -97,7 +97,7 @@ export async function run() {
 function getUserAgent(prevUserAgent: string): string {
    const actionName = process.env.GITHUB_ACTION_REPOSITORY || ACTION_NAME
    const runRepo = process.env.GITHUB_REPOSITORY || ''
-   const runRepoHash = crypto.createHash('sha256').update(runRepo).digest('hex')
+   const runRepoHash = createHash('sha256').update(runRepo).digest('hex')
    const runId = process.env.GITHUB_RUN_ID
    const newUserAgent = `GitHubActions/${actionName}(${runRepoHash}; ${runId})`
 


### PR DESCRIPTION
based on warning:
`npm WARN deprecated crypto@1.0.1: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.`

switch to built-in package