### PR TITLE
enable write permission after token changes

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,5 +11,7 @@ on:
 jobs:
    release:
       uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@a705b2ab6a3ee889f2b0d925ad0bd2f9eb733ce6
+      permissions:
+         contents: write
       with:
          changelogPath: ./CHANGELOG.md


### PR DESCRIPTION
the Azure org's permission changes now require permission blocks for all workflows, so we need to add write permission to the release pipeline