### PR TITLE
release workflow update to tag and add prebuild step to unblock

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,8 +10,9 @@ on:
 
 jobs:
    release:
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@v1
       permissions:
+         actions: read
          contents: write
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@v1
       with:
          changelogPath: ./CHANGELOG.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
    release:
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@a705b2ab6a3ee889f2b0d925ad0bd2f9eb733ce6
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@v1
       permissions:
          contents: write
       with:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
    "private": true,
    "main": "lib/login.js",
    "scripts": {
+      "prebuild": "npm i @vercel/ncc",
       "build": "ncc build src/index.ts -o lib",
       "test": "jest",
       "test-coverage": "jest --coverage",


### PR DESCRIPTION
the updated release workflows require a prebuild step to install ncc, this PR adds that and also updates the release workflow to use a tag tracking major version