### PR TITLE
Security: remove outdated action, fix all prettier fo repo.

### DIFF
--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -1,4 +1,4 @@
-name: 'Run prettify'
+name: 'Run Prettify'
 on:
    pull_request:
    push:
@@ -10,9 +10,16 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          - name: Checkout Repository
-           uses: actions/checkout@v4
+           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-         - name: Enforce Prettier
-           uses: actionsx/prettier@v3
+         - name: Setup Node.js
+           uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
            with:
-              args: --check .
+              node-version: 'lts/*'
+              cache: 'npm'
+
+         - name: Install Dependencies
+           run: npm ci
+
+         - name: Run Prettier Check
+           run: npx prettier --check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,24 @@
 
 ### Added
 
--  #135 Added Fleet Functionality
+- #135 Added Fleet Functionality
 
 ## [4.0.1] - 2024-09-06
 
 ### Changed
 
--  #117 Upgrading typescript to 5
--  #116 Added dependabot
+- #117 Upgrading typescript to 5
+- #116 Added dependabot
 
 ## [4.0.0] - 2024-02-09
 
 ### Changed
 
--  #109 **Breaking Change** Upgrade to node20 as node16 is deprecated, test fixes
+- #109 **Breaking Change** Upgrade to node20 as node16 is deprecated, test fixes
 
 ## [3.3.0] - 2024-01-22
 
 ### Added
 
--  #77 Add az user agent
--  #97 Add support for --public-fqdn option
+- #77 Add az user agent
+- #97 Add support for --public-fqdn option

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,6 +4,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 Resources:
 
--  [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
--  [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
--  Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,13 +14,13 @@ You should receive a response within 24 hours. If for some reason you do not, pl
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
--  Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
--  Full paths of source file(s) related to the manifestation of the issue
--  The location of the affected source code (tag/branch/commit or direct URL)
--  Any special configuration required to reproduce the issue
--  Step-by-step instructions to reproduce the issue
--  Proof-of-concept or exploit code (if possible)
--  Impact of the issue, including how an attacker might exploit the issue
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 


### PR DESCRIPTION
There are few repos with this issue, especially we can do this natively so worth to update for all effected repo and that will be great for once and all as we have supporting dependabot to take over post this.

Please note the `action` used in this repo is Over 2 year old as last release we can do it more direct approach and not worry about the third party action in place. (https://github.com/actionsx/prettier )

This PR also fixes the old issues with styling for this repo and now the whole repo will pass for the actual check for prettier.

This PR improves the **Prettier check workflow** by replacing the third-party `actionsx/prettier` action with a direct `npx prettier --check` command. It also:  

- Ensures **faster builds** via `setup-node`.  
- Uses `npm ci` for a **cleaner and more consistent** dependency installation.  

This enhances **transparency, flexibility, and performance** in enforcing Prettier formatting. 

Thanks heaps.