### PR TITLE
adding resource-type input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
       description: 'Get private cluster credential with server address to be public fqdn.  Values: true or false'
       default: false
       required: false
+   resource-type:
+      description: Either Microsoft.ContainerService/managedClusters or Microsoft.ContainerService/fleets'.
+      required: false
+      default: 'Microsoft.ContainerService/managedClusters'
 branding:
    color: 'green'
 runs:


### PR DESCRIPTION
Currently, not adding the new resource-type input in action.yml is causing this warning:
![image](https://github.com/user-attachments/assets/635a949c-ba8a-4701-9c14-20ec8e28aca9)

To avoid confusion, we will add it to remove the warning.