### PR TITLE
chore: pin release workflow to SHA for supply chain safety

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,6 +13,6 @@ jobs:
       permissions:
          actions: read
          contents: write
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@v1
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@3c677ba5ab58f5c5c1a6f0cfb176b333b1f27405 # v1
       with:
          changelogPath: ./CHANGELOG.md


### PR DESCRIPTION
## Summary

Pin `Azure/action-release-workflows` in `release-pr.yml` to commit SHA (`3c677ba5ab58f5c5c1a6f0cfb176b333b1f27405`) instead of mutable `@v1` tag.

Mutable tags are a supply chain risk — if the tag is moved to point at a compromised commit, all consuming workflows are affected. SHA pinning ensures immutability. Dependabot will automatically open PRs for updates.