### PR TITLE
chore: reduce dependabot frequency to monthly with 1-week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: weekly
+        interval: monthly
+     cooldown:
+        default-days: 7
      groups:
         actions:
            patterns:
@@ -11,7 +13,9 @@ updates:
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: weekly
+        interval: monthly
+     cooldown:
+        default-days: 7
      groups:
         actions:
            patterns:


### PR DESCRIPTION
## What

Reduce Dependabot version-update frequency and add a cooldown window.

- `schedule.interval`: `weekly` → `monthly` (both npm and github-actions ecosystems)
- Add `cooldown.default-days: 7` so a new release must age 1 week before a PR is opened

## Why

Cuts down on Dependabot PR churn while still keeping dependencies current. The 1-week cooldown avoids churn from same-week patch re-releases.

## Notes

Security updates are unaffected by `cooldown` (they ignore it), so vulnerability fixes still flow immediately.