### PR TITLE
chore: bump prettier to 3.9 and reformat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             "@types/node": "^26.0.0",
             "@vitest/coverage-v8": "^4.1.9",
             "esbuild": "^0.28.1",
-            "prettier": "^3.8.4",
+            "prettier": "^3.9.4",
             "typescript": "^6.0.3",
             "vitest": "^4.0.18"
          }
@@ -1740,9 +1740,9 @@
          }
       },
       "node_modules/prettier": {
-         "version": "3.8.4",
-         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-         "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+         "version": "3.9.4",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prettier/-/prettier-3.9.4.tgz",
+         "integrity": "sha1-qcR3zxYUN2vR9rvFk9jA1BS87Ic=",
          "dev": true,
          "license": "MIT",
          "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "@types/node": "^26.0.0",
       "@vitest/coverage-v8": "^4.1.9",
       "esbuild": "^0.28.1",
-      "prettier": "^3.8.4",
+      "prettier": "^3.9.4",
       "typescript": "^6.0.3",
       "vitest": "^4.0.18"
    }

--- a/src/run.ts
+++ b/src/run.ts
@@ -33,8 +33,7 @@ export async function run() {
       const resourceTypeManagedCluster =
          'microsoft.containerservice/managedclusters'
       type ResourceType =
-         | typeof resourceTypeFleet
-         | typeof resourceTypeManagedCluster
+         typeof resourceTypeFleet | typeof resourceTypeManagedCluster
       const resourceInput = (
          core.getInput('resource-type') ||
          'Microsoft.ContainerService/managedClusters'


### PR DESCRIPTION
## What

Bumps `prettier` from 3.8 to ^3.9.4 and reformats `src/run.ts`.

## Why

Prettier 3.9 changed union-type formatting. The `Prettier Check` gate runs `prettier --check .` across the whole repo, so any dependabot PR that bumps prettier to 3.9 (e.g. #251) fails on `src/run.ts` — a file it doesn't touch.

The bump and the reformat must land together: reformatting alone breaks the gate under 3.8, and bumping alone breaks it under 3.9. This PR does both, unblocking #251 and future prettier bumps.

## Verification

- `prettier --check .` → all files pass
- `npm run build` → ok
- `npm test` → 11 passed