### PR TITLE
chore: enforce 7-day dependency freshness controls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,28 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: monthly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
      cooldown:
         default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: monthly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
      cooldown:
         default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch

--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -15,8 +15,11 @@ jobs:
          - name: Setup Node.js
            uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
-              node-version: 'lts/*'
+              node-version: '24'
               cache: 'npm'
+
+         - name: Ensure npm supports min-release-age
+           run: npm install -g npm@^11.10.0
 
          - name: Install Dependencies
            run: npm ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,15 @@ jobs:
       steps:
          - uses: actions/checkout@v7
 
+         - name: Setup Node.js
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+           with:
+              node-version: '24'
+              cache: 'npm'
+
+         - name: Ensure npm supports min-release-age
+           run: npm install -g npm@^11.10.0
+
          - name: Install dependencies
            run: npm ci
 
@@ -31,6 +40,15 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          - uses: actions/checkout@v7
+
+         - name: Setup Node.js
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+           with:
+              node-version: '24'
+              cache: 'npm'
+
+         - name: Ensure npm supports min-release-age
+           run: npm install -g npm@^11.10.0
 
          - name: Run unit tests
            run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ If you are executing this Action as a non-admin user, you need to toggle the opt
      use-kubelogin: 'true'
 ```
 
+## Development
+
+This repository enforces a **7-day dependency freshness ("bake") period**: newly
+published npm packages are not adopted until they are at least 7 days old. This
+is enforced two ways:
+
+- **Dependabot** uses a 7-day `cooldown` and runs on the 1st and 15th of each
+  month, grouping minor/patch updates into a single PR (major updates get
+  individual PRs).
+- **`.npmrc`** sets `min-release-age=7` (days) with `engine-strict=true`, which
+  requires **npm >= 11.10.0**. `npm install` will fail on older npm with a clear
+  message — upgrade with `npm install -g npm@latest`.
+
+**Security exception:** to adopt an urgent patch that is less than 7 days old,
+install it once with the age check disabled:
+
+```sh
+npm install <pkg> --config.min-release-age=0
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ is enforced two ways:
 install it once with the age check disabled:
 
 ```sh
-npm install <pkg> --config.min-release-age=0
+npm install <pkg> --min-release-age=0
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
          }
       },
       "node_modules/@actions/http-client": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-         "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+         "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
          "license": "MIT",
          "dependencies": {
             "tunnel": "^0.0.6",
@@ -62,9 +62,9 @@
          "license": "MIT"
       },
       "node_modules/@babel/helper-string-parser": {
-         "version": "7.27.1",
-         "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-         "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+         "version": "7.29.7",
+         "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+         "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -72,9 +72,9 @@
          }
       },
       "node_modules/@babel/helper-validator-identifier": {
-         "version": "7.28.5",
-         "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-         "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+         "version": "7.29.7",
+         "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+         "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -82,13 +82,13 @@
          }
       },
       "node_modules/@babel/parser": {
-         "version": "7.29.0",
-         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-         "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+         "version": "7.29.7",
+         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+         "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "^7.29.7"
          },
          "bin": {
             "parser": "bin/babel-parser.js"
@@ -98,14 +98,14 @@
          }
       },
       "node_modules/@babel/types": {
-         "version": "7.29.0",
-         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-         "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+         "version": "7.29.7",
+         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+         "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "^7.29.7",
+            "@babel/helper-validator-identifier": "^7.29.7"
          },
          "engines": {
             "node": ">=6.9.0"
@@ -122,35 +122,38 @@
          }
       },
       "node_modules/@emnapi/core": {
-         "version": "1.11.1",
-         "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-         "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+         "version": "2.0.0-alpha.3",
+         "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+         "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
          "dev": true,
          "license": "MIT",
          "optional": true,
+         "peer": true,
          "dependencies": {
-            "@emnapi/wasi-threads": "1.2.2",
+            "@emnapi/wasi-threads": "2.0.1",
             "tslib": "^2.4.0"
          }
       },
       "node_modules/@emnapi/runtime": {
-         "version": "1.11.1",
-         "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-         "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+         "version": "2.0.0-alpha.3",
+         "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+         "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
          "dev": true,
          "license": "MIT",
          "optional": true,
+         "peer": true,
          "dependencies": {
             "tslib": "^2.4.0"
          }
       },
       "node_modules/@emnapi/wasi-threads": {
-         "version": "1.2.2",
-         "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-         "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+         "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
          "dev": true,
          "license": "MIT",
          "optional": true,
+         "peer": true,
          "dependencies": {
             "tslib": "^2.4.0"
          }
@@ -626,22 +629,25 @@
          }
       },
       "node_modules/@napi-rs/wasm-runtime": {
-         "version": "1.1.6",
-         "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-         "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+         "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
          "dev": true,
          "license": "MIT",
          "optional": true,
          "dependencies": {
             "@tybys/wasm-util": "^0.10.3"
          },
+         "engines": {
+            "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+         },
          "funding": {
             "type": "github",
             "url": "https://github.com/sponsors/Brooooooklyn"
          },
          "peerDependencies": {
-            "@emnapi/core": "^1.7.1",
-            "@emnapi/runtime": "^1.7.1"
+            "@emnapi/core": "^2.0.0-alpha.3",
+            "@emnapi/runtime": "^2.0.0-alpha.3"
          }
       },
       "node_modules/@oxc-project/types": {
@@ -895,6 +901,40 @@
             "node": "^20.19.0 || >=22.12.0"
          }
       },
+      "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+         "version": "1.11.1",
+         "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+         "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "@emnapi/wasi-threads": "1.2.2",
+            "tslib": "^2.4.0"
+         }
+      },
+      "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+         "version": "1.11.1",
+         "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+         "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "tslib": "^2.4.0"
+         }
+      },
+      "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+         "version": "1.2.2",
+         "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+         "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "dependencies": {
+            "tslib": "^2.4.0"
+         }
+      },
       "node_modules/@rolldown/binding-win32-arm64-msvc": {
          "version": "1.1.5",
          "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
@@ -973,16 +1013,16 @@
          "license": "MIT"
       },
       "node_modules/@types/estree": {
-         "version": "1.0.8",
-         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-         "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+         "version": "1.0.9",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+         "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/@types/node": {
-         "version": "26.1.1",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-         "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+         "version": "26.1.2",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+         "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1484,9 +1524,9 @@
          }
       },
       "node_modules/ast-v8-to-istanbul": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-         "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+         "version": "1.0.5",
+         "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+         "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1523,9 +1563,9 @@
          }
       },
       "node_modules/es-module-lexer": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-         "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+         "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
          "dev": true,
          "license": "MIT"
       },
@@ -1582,9 +1622,9 @@
          }
       },
       "node_modules/expect-type": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-         "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+         "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
          "dev": true,
          "license": "Apache-2.0",
          "engines": {
@@ -1703,9 +1743,9 @@
          "license": "MIT"
       },
       "node_modules/lightningcss": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-         "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+         "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
          "dev": true,
          "license": "MPL-2.0",
          "dependencies": {
@@ -1719,23 +1759,23 @@
             "url": "https://opencollective.com/parcel"
          },
          "optionalDependencies": {
-            "lightningcss-android-arm64": "1.32.0",
-            "lightningcss-darwin-arm64": "1.32.0",
-            "lightningcss-darwin-x64": "1.32.0",
-            "lightningcss-freebsd-x64": "1.32.0",
-            "lightningcss-linux-arm-gnueabihf": "1.32.0",
-            "lightningcss-linux-arm64-gnu": "1.32.0",
-            "lightningcss-linux-arm64-musl": "1.32.0",
-            "lightningcss-linux-x64-gnu": "1.32.0",
-            "lightningcss-linux-x64-musl": "1.32.0",
-            "lightningcss-win32-arm64-msvc": "1.32.0",
-            "lightningcss-win32-x64-msvc": "1.32.0"
+            "lightningcss-android-arm64": "1.33.0",
+            "lightningcss-darwin-arm64": "1.33.0",
+            "lightningcss-darwin-x64": "1.33.0",
+            "lightningcss-freebsd-x64": "1.33.0",
+            "lightningcss-linux-arm-gnueabihf": "1.33.0",
+            "lightningcss-linux-arm64-gnu": "1.33.0",
+            "lightningcss-linux-arm64-musl": "1.33.0",
+            "lightningcss-linux-x64-gnu": "1.33.0",
+            "lightningcss-linux-x64-musl": "1.33.0",
+            "lightningcss-win32-arm64-msvc": "1.33.0",
+            "lightningcss-win32-x64-msvc": "1.33.0"
          }
       },
       "node_modules/lightningcss-android-arm64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-         "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+         "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
          "cpu": [
             "arm64"
          ],
@@ -1754,9 +1794,9 @@
          }
       },
       "node_modules/lightningcss-darwin-arm64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-         "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+         "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
          "cpu": [
             "arm64"
          ],
@@ -1775,9 +1815,9 @@
          }
       },
       "node_modules/lightningcss-darwin-x64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-         "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+         "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
          "cpu": [
             "x64"
          ],
@@ -1796,9 +1836,9 @@
          }
       },
       "node_modules/lightningcss-freebsd-x64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-         "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+         "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
          "cpu": [
             "x64"
          ],
@@ -1817,9 +1857,9 @@
          }
       },
       "node_modules/lightningcss-linux-arm-gnueabihf": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-         "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+         "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
          "cpu": [
             "arm"
          ],
@@ -1838,9 +1878,9 @@
          }
       },
       "node_modules/lightningcss-linux-arm64-gnu": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-         "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+         "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
          "cpu": [
             "arm64"
          ],
@@ -1862,9 +1902,9 @@
          }
       },
       "node_modules/lightningcss-linux-arm64-musl": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-         "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+         "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
          "cpu": [
             "arm64"
          ],
@@ -1886,9 +1926,9 @@
          }
       },
       "node_modules/lightningcss-linux-x64-gnu": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-         "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+         "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
          "cpu": [
             "x64"
          ],
@@ -1910,9 +1950,9 @@
          }
       },
       "node_modules/lightningcss-linux-x64-musl": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-         "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+         "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
          "cpu": [
             "x64"
          ],
@@ -1934,9 +1974,9 @@
          }
       },
       "node_modules/lightningcss-win32-arm64-msvc": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-         "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+         "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
          "cpu": [
             "arm64"
          ],
@@ -1955,9 +1995,9 @@
          }
       },
       "node_modules/lightningcss-win32-x64-msvc": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-         "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+         "version": "1.33.0",
+         "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+         "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
          "cpu": [
             "x64"
          ],
@@ -1986,13 +2026,13 @@
          }
       },
       "node_modules/magicast": {
-         "version": "0.5.2",
-         "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-         "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+         "version": "0.5.3",
+         "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+         "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/parser": "^7.29.0",
+            "@babel/parser": "^7.29.3",
             "@babel/types": "^7.29.0",
             "source-map-js": "^1.2.1"
          }
@@ -2011,19 +2051,6 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/sindresorhus"
-         }
-      },
-      "node_modules/make-dir/node_modules/semver": {
-         "version": "7.7.2",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-         "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-         "dev": true,
-         "license": "ISC",
-         "bin": {
-            "semver": "bin/semver.js"
-         },
-         "engines": {
-            "node": ">=10"
          }
       },
       "node_modules/nanoid": {
@@ -2046,15 +2073,18 @@
          }
       },
       "node_modules/obug": {
-         "version": "2.1.1",
-         "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-         "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+         "version": "2.1.4",
+         "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+         "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
          "dev": true,
          "funding": [
             "https://github.com/sponsors/sxzz",
             "https://opencollective.com/debug"
          ],
-         "license": "MIT"
+         "license": "MIT",
+         "engines": {
+            "node": ">=12.20.0"
+         }
       },
       "node_modules/pathe": {
          "version": "2.0.3",
@@ -2084,9 +2114,9 @@
          }
       },
       "node_modules/postcss": {
-         "version": "8.5.19",
-         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-         "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+         "version": "8.5.25",
+         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+         "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
          "dev": true,
          "funding": [
             {
@@ -2104,7 +2134,7 @@
          ],
          "license": "MIT",
          "dependencies": {
-            "nanoid": "^3.3.12",
+            "nanoid": "^3.3.16",
             "picocolors": "^1.1.1",
             "source-map-js": "^1.2.1"
          },
@@ -2113,9 +2143,9 @@
          }
       },
       "node_modules/prettier": {
-         "version": "3.9.5",
-         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-         "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+         "version": "3.9.6",
+         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+         "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
          "dev": true,
          "license": "MIT",
          "bin": {
@@ -2162,6 +2192,19 @@
             "@rolldown/binding-win32-x64-msvc": "1.1.5"
          }
       },
+      "node_modules/semver": {
+         "version": "7.8.5",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+         "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+         "dev": true,
+         "license": "ISC",
+         "bin": {
+            "semver": "bin/semver.js"
+         },
+         "engines": {
+            "node": ">=10"
+         }
+      },
       "node_modules/siginfo": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2187,9 +2230,9 @@
          "license": "MIT"
       },
       "node_modules/std-env": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-         "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+         "version": "4.2.0",
+         "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+         "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
          "dev": true,
          "license": "MIT"
       },
@@ -2214,9 +2257,9 @@
          "license": "MIT"
       },
       "node_modules/tinyexec": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-         "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+         "version": "1.2.4",
+         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+         "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -2241,9 +2284,9 @@
          }
       },
       "node_modules/tinyrainbow": {
-         "version": "3.1.0",
-         "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-         "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+         "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -2303,9 +2346,9 @@
          }
       },
       "node_modules/undici": {
-         "version": "6.27.0",
-         "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-         "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+         "version": "6.28.0",
+         "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+         "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
          "license": "MIT",
          "engines": {
             "node": ">=18.17"
@@ -2319,16 +2362,16 @@
          "license": "MIT"
       },
       "node_modules/vite": {
-         "version": "8.1.4",
-         "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-         "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+         "version": "8.1.5",
+         "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+         "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "lightningcss": "^1.32.0",
             "picomatch": "^4.0.5",
-            "postcss": "^8.5.16",
-            "rolldown": "~1.1.4",
+            "postcss": "^8.5.17",
+            "rolldown": "~1.1.5",
             "tinyglobby": "^0.2.17"
          },
          "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
             "prettier": "^3.9.5",
             "typescript": "^7.0.2",
             "vitest": "^4.0.18"
+         },
+         "engines": {
+            "npm": ">=11.10.0"
          }
       },
       "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
    ],
    "author": "GitHub",
    "license": "MIT",
+   "engines": {
+      "npm": ">=11.10.0"
+   },
    "dependencies": {
       "@actions/core": "^3.0.1",
       "@actions/exec": "^3.0.0",


### PR DESCRIPTION
Enforces a 7-day dependency bake period so newly published packages aren't adopted until they've had time to be vetted/yanked (supply-chain safety).

- **Dependabot**: schedule on the 1st & 15th via `cron '0 8 1,15 * *'`; keep 7-day `cooldown`; group minor/patch into one PR (majors separate) for both npm and github-actions ecosystems.
- **`.npmrc`**: `min-release-age=7` (days) + `engine-strict=true` — refuses versions <7d old at install time.
- Silently ignored below npm 11.10.0, so **`engines.npm >=11.10.0`** makes `npm install` fail fast on unsupported npm.
- CI (`unit-tests`, `prettify-code`) pinned to node 24 + `npm install -g npm@^11.10.0` so the rule is honored in CI.
- README documents the policy + security escape hatch.

Verified: `npm ci`, build, 11 tests, prettier all pass.

Escape hatch (README): urgent patch <7d → `npm install <pkg> --min-release-age=0`.


Lockfile regenerated from scratch (`rm -rf node_modules package-lock.json && npm install`) so it resolves cleanly against registry.npmjs.org under the new `min-release-age=7` rule.
