### PR TITLE
release: prepare v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [5.0.1] - 2026-09-04
+
+### Changed
+
+- #264 [Pin GitHub Actions to full-length commit SHAs](https://github.com/Azure/aks-set-context/pull/264)
+- #258 [Enforce 7-day dependency freshness controls](https://github.com/Azure/aks-set-context/pull/258)
+- #252 [Reduce dependabot frequency to monthly with 1-week cooldown](https://github.com/Azure/aks-set-context/pull/252)
+- #241 [Pin release workflow to SHA for supply chain safety](https://github.com/Azure/aks-set-context/pull/241)
+- #253 [Bump prettier to 3.9 and reformat src/run.ts](https://github.com/Azure/aks-set-context/pull/253)
+- #267 [Bump actions/stale from 10.4.0 to 11.0.0](https://github.com/Azure/aks-set-context/pull/267)
+- #266 [Bump the minor-and-patch group with 4 updates](https://github.com/Azure/aks-set-context/pull/266)
+- #265 [Bump the minor-and-patch group across 1 directory with 2 updates](https://github.com/Azure/aks-set-context/pull/265)
+- #262 [Bump @types/node in the minor-and-patch group](https://github.com/Azure/aks-set-context/pull/262)
+- #255 [Bump prettier from 3.9.4 to 3.9.5 in the actions group](https://github.com/Azure/aks-set-context/pull/255)
+- #254 [Bump the actions group across 1 directory with 4 updates](https://github.com/Azure/aks-set-context/pull/254)
+- #248 [Bump undici from 6.24.1 to 6.27.0](https://github.com/Azure/aks-set-context/pull/248)
+- #247 [Bump actions/checkout in /.github/workflows in the actions group](https://github.com/Azure/aks-set-context/pull/247)
+- #246 [Bump @types/node from 25.9.3 to 26.0.0 in the actions group](https://github.com/Azure/aks-set-context/pull/246)
+- #245 [Bump the actions group with 4 updates](https://github.com/Azure/aks-set-context/pull/245)
+- #244 [Bump esbuild from 0.28.0 to 0.28.1](https://github.com/Azure/aks-set-context/pull/244)
+- #243 [Bump @types/node from 25.9.1 to 25.9.2 in the actions group](https://github.com/Azure/aks-set-context/pull/243)
+- #242 [Bump the actions group with 2 updates](https://github.com/Azure/aks-set-context/pull/242)
+- #240 [Bump the actions group with 3 updates](https://github.com/Azure/aks-set-context/pull/240)
+- #239 [Bump @types/node from 25.7.0 to 25.9.0 in the actions group](https://github.com/Azure/aks-set-context/pull/239)
+- #238 [Bump the actions group with 3 updates](https://github.com/Azure/aks-set-context/pull/238)
+- #237 [Bump the actions group with 3 updates](https://github.com/Azure/aks-set-context/pull/237)
+- #236 [Bump actions/setup-node in /.github/workflows in the actions group](https://github.com/Azure/aks-set-context/pull/236)
+- #235 [Bump the actions group with 2 updates](https://github.com/Azure/aks-set-context/pull/235)
+- #234 [Bump the actions group with 4 updates](https://github.com/Azure/aks-set-context/pull/234)
+- #233 [Bump the actions group with 2 updates](https://github.com/Azure/aks-set-context/pull/233)
+- #232 [Bump vite from 8.0.3 to 8.0.5](https://github.com/Azure/aks-set-context/pull/232)
+- #231 [Bump the actions group with 2 updates](https://github.com/Azure/aks-set-context/pull/231)
+
 ## [5.0.0] - 2026-03-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "aks-set-context-action",
-   "version": "5.0.0",
+   "version": "5.0.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "aks-set-context-action",
-         "version": "5.0.0",
+         "version": "5.0.1",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.1",
@@ -82,13 +82,13 @@
          }
       },
       "node_modules/@babel/parser": {
-         "version": "7.29.7",
-         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-         "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+         "version": "7.29.8",
+         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+         "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/types": "^7.29.7"
+            "@babel/types": "^7.29.8"
          },
          "bin": {
             "parser": "bin/babel-parser.js"
@@ -98,9 +98,9 @@
          }
       },
       "node_modules/@babel/types": {
-         "version": "7.29.7",
-         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-         "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+         "version": "7.29.8",
+         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+         "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -574,9 +574,9 @@
          }
       },
       "node_modules/@jridgewell/sourcemap-codec": {
-         "version": "1.5.5",
-         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-         "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+         "version": "1.6.0",
+         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+         "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
          "dev": true,
          "license": "MIT"
       },
@@ -592,9 +592,9 @@
          }
       },
       "node_modules/@oxc-project/types": {
-         "version": "0.146.0",
-         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
-         "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+         "version": "0.147.0",
+         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+         "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -602,9 +602,9 @@
          }
       },
       "node_modules/@rolldown/binding-android-arm-eabi": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
-         "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+         "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
          "cpu": [
             "arm"
          ],
@@ -619,9 +619,9 @@
          }
       },
       "node_modules/@rolldown/binding-android-arm64": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
-         "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+         "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
          "cpu": [
             "arm64"
          ],
@@ -636,9 +636,9 @@
          }
       },
       "node_modules/@rolldown/binding-darwin-arm64": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
-         "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+         "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
          "cpu": [
             "arm64"
          ],
@@ -653,9 +653,9 @@
          }
       },
       "node_modules/@rolldown/binding-darwin-x64": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
-         "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+         "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
          "cpu": [
             "x64"
          ],
@@ -670,9 +670,9 @@
          }
       },
       "node_modules/@rolldown/binding-freebsd-x64": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
-         "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+         "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
          "cpu": [
             "x64"
          ],
@@ -687,9 +687,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
-         "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+         "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
          "cpu": [
             "arm"
          ],
@@ -704,9 +704,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm64-gnu": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
-         "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+         "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
          "cpu": [
             "arm64"
          ],
@@ -724,9 +724,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm64-musl": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
-         "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+         "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
          "cpu": [
             "arm64"
          ],
@@ -744,9 +744,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
-         "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+         "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
          "cpu": [
             "ppc64"
          ],
@@ -764,9 +764,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-s390x-gnu": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
-         "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+         "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
          "cpu": [
             "s390x"
          ],
@@ -784,9 +784,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-x64-gnu": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
-         "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+         "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
          "cpu": [
             "x64"
          ],
@@ -804,9 +804,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-x64-musl": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
-         "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+         "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
          "cpu": [
             "x64"
          ],
@@ -824,9 +824,9 @@
          }
       },
       "node_modules/@rolldown/binding-openharmony-arm64": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
-         "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+         "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
          "cpu": [
             "arm64"
          ],
@@ -841,9 +841,9 @@
          }
       },
       "node_modules/@rolldown/binding-win32-arm64-msvc": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
-         "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+         "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
          "cpu": [
             "arm64"
          ],
@@ -858,9 +858,9 @@
          }
       },
       "node_modules/@rolldown/binding-win32-x64-msvc": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
-         "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+         "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
          "cpu": [
             "x64"
          ],
@@ -914,9 +914,9 @@
          "license": "MIT"
       },
       "node_modules/@types/node": {
-         "version": "26.3.0",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
-         "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+         "version": "26.4.0",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+         "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1457,9 +1457,9 @@
          }
       },
       "node_modules/es-module-lexer": {
-         "version": "2.3.1",
-         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-         "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+         "version": "2.3.2",
+         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+         "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
          "dev": true,
          "license": "MIT"
       },
@@ -1920,14 +1920,14 @@
          }
       },
       "node_modules/magicast": {
-         "version": "0.5.3",
-         "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-         "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+         "version": "0.5.4",
+         "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+         "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/parser": "^7.29.3",
-            "@babel/types": "^7.29.0",
+            "@babel/parser": "^7.29.7",
+            "@babel/types": "^7.29.7",
             "source-map-js": "^1.2.1"
          }
       },
@@ -2053,13 +2053,13 @@
          }
       },
       "node_modules/rolldown": {
-         "version": "1.2.5",
-         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
-         "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+         "version": "1.2.6",
+         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+         "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@oxc-project/types": "=0.146.0",
+            "@oxc-project/types": "=0.147.0",
             "@rolldown/pluginutils": "^1.0.0"
          },
          "bin": {
@@ -2069,21 +2069,21 @@
             "node": "^20.19.0 || >=22.12.0"
          },
          "optionalDependencies": {
-            "@rolldown/binding-android-arm-eabi": "1.2.5",
-            "@rolldown/binding-android-arm64": "1.2.5",
-            "@rolldown/binding-darwin-arm64": "1.2.5",
-            "@rolldown/binding-darwin-x64": "1.2.5",
-            "@rolldown/binding-freebsd-x64": "1.2.5",
-            "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
-            "@rolldown/binding-linux-arm64-gnu": "1.2.5",
-            "@rolldown/binding-linux-arm64-musl": "1.2.5",
-            "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
-            "@rolldown/binding-linux-s390x-gnu": "1.2.5",
-            "@rolldown/binding-linux-x64-gnu": "1.2.5",
-            "@rolldown/binding-linux-x64-musl": "1.2.5",
-            "@rolldown/binding-openharmony-arm64": "1.2.5",
-            "@rolldown/binding-win32-arm64-msvc": "1.2.5",
-            "@rolldown/binding-win32-x64-msvc": "1.2.5"
+            "@rolldown/binding-android-arm-eabi": "1.2.6",
+            "@rolldown/binding-android-arm64": "1.2.6",
+            "@rolldown/binding-darwin-arm64": "1.2.6",
+            "@rolldown/binding-darwin-x64": "1.2.6",
+            "@rolldown/binding-freebsd-x64": "1.2.6",
+            "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+            "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+            "@rolldown/binding-linux-arm64-musl": "1.2.6",
+            "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+            "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+            "@rolldown/binding-linux-x64-gnu": "1.2.6",
+            "@rolldown/binding-linux-x64-musl": "1.2.6",
+            "@rolldown/binding-openharmony-arm64": "1.2.6",
+            "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+            "@rolldown/binding-win32-x64-msvc": "1.2.6"
          }
       },
       "node_modules/semver": {
@@ -2151,9 +2151,9 @@
          "license": "MIT"
       },
       "node_modules/tinyexec": {
-         "version": "1.2.4",
-         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-         "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+         "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
          "dev": true,
          "license": "MIT",
          "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "aks-set-context-action",
-   "version": "5.0.0",
+   "version": "5.0.1",
    "private": true,
    "type": "module",
    "main": "lib/index.js",


### PR DESCRIPTION
Patch release covering the 28 commits merged since v5.0.0.

- bump version to 5.0.1 (package.json + package-lock.json)
- add CHANGELOG entry for all 28 PRs since v5.0.0
- lockfile fully regenerated (`rm -rf node_modules package-lock.json && npm install`); 26 `@esbuild/*` platform packages retained so `npm ci` stays green on Linux
- merging triggers the release workflow via the CHANGELOG.md change on main

## Why patch

No action interface changes: inputs/outputs are untouched and `action.yml` stays on `node24`. Contents are dependabot bumps, CI supply-chain hardening (SHA pinning, dependency freshness controls), and a prettier reformat of `src/run.ts` with no behavior change.

## Verification

- `npm run build` exits 0 (810.6kb ESM bundle, correct `createRequire` banner)
- `npm test` 11/11 passing
- `npm run format-check` clean